### PR TITLE
Change Options to support an enum for input.

### DIFF
--- a/src/bin/wasm-snip.rs
+++ b/src/bin/wasm-snip.rs
@@ -19,7 +19,7 @@ fn try_main() -> Result<(), failure::Error> {
 
     let mut opts = wasm_snip::Options::default();
 
-    opts.input = path::PathBuf::from(matches.value_of("input").unwrap());
+    opts.input = wasm_snip::Input::File(path::PathBuf::from(matches.value_of("input").unwrap()));
 
     opts.functions = matches
         .values_of("function")
@@ -125,7 +125,7 @@ Very helpful when shrinking the size of WebAssembly binaries!
             clap::Arg::with_name("skip_producers_section")
                 .required(false)
                 .long("skip-producers-section")
-                .help("Do not emit the 'producers' custom section.")
+                .help("Do not emit the 'producers' custom section."),
         )
         .get_matches()
 }


### PR DESCRIPTION
The two cases supported initially are file (as before) and a Vec<u8> wasm blob. This could be extended later to support a walrus::Module directly to be symmetrical with the output.

The reason I would like to have this change is for using snip in another crate where we have wasm in memory already.